### PR TITLE
Upgrade grunt-appcache for large projects using bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,20 @@ grunt.initConfig({
 ### Options
 
 #### options.basePath
-Type: `String`, 
-Default value: `process.cwd()`.
+Type: `String`
+Default value: `process.cwd()`
 
 The absolute or relative path to the directory to consider as the root of the application for which to generate the cache manifest.
 
 #### options.ignoreManifest
-Type: `Boolean`, 
-Default value: `true`.
+Type: `Boolean`
+Default value: `true`
 
 Specifies if to ignore the cache manifest itself from the list of files to insert in the "CACHE:" section.
 
 #### options.preferOnline
-Type: `Boolean`, 
-Default value: `false`.
+Type: `Boolean`
+Default value: `false`
 
 Specifies whether to write the "prefer-online" entry in the "SETTINGS:" section or not. [More information](http://www.whatwg.org/specs/web-apps/current-work/multipage/browsers.html#appcache).  
 
@@ -59,32 +59,30 @@ Specifies whether to write the "prefer-online" entry in the "SETTINGS:" section 
 
 #### dest
 
-`String`, Mandatory. Indicating the output path for the AppCache manifest.
+`String` indicating the output path for the AppCache manifest. Mandatory. 
 
 #### baseUrl
-Type: `String`,
-Default value: `undefined`.
+Type: `String`
+Default value: `undefined`
 
-The base URL to prepand to all expanded cache entries. It should be let to `undefined` in case of
-webapp, or set to `/bower_components/mywebcomponent` in case of bower module.
+The base URL to prepend to all expanded cache entries. In case of a Bower module, you can set this to `/bower_components/mywebcomponent`.
 
 #### includes
-Type: `Grunt globbing pattern`,
-Default value: `undefined`.
+Type: `Grunt globbing pattern`
+Default value: `undefined`
 [globbing pattern spec](http://gruntjs.com/configuring-tasks#globbing-patterns)
 
 The purposes is to merge all manifest files that match the globbing pattern into this generated
-manifest appcache. Each sections : cache, network and fallback are merged and then filled with
-`cache`, `network` and `fallback` target fields. It is very useful when 
-you create you own bower component with this grunt appcahe task or when you use a third party
-components that include his appcache manifest. See Bower usage examples bellow.
+manifest appcache. The contents of each matching files' sections are merged together, and subsequently added to the final `cache`, `network` and `fallback` target fields. It is very useful when 
+you create you own Bower component with this Grunt Task or when you use a third party
+component that include their appcache manifest. See Bower usage examples below.
 
 #### cache
 
 A descriptor for the "CACHE:" entries. A cache descriptor can be either :
 
 Type: `Grunt globbing pattern` 
-Default value: `[]`.
+Default value: `[]`
 [globbing pattern spec](http://gruntjs.com/configuring-tasks#globbing-patterns)
 
 Alternatively, this argument can be an `Object`.
@@ -92,11 +90,11 @@ Alternatively, this argument can be an `Object`.
 Type: `Object`
 Default Value: `{ patterns: [], literals: [], pageslinks: []}` 
 
-Containing the optional properties `patterns` (a cache descriptor, as defined earlier).
+* Containing the optional properties `patterns` (a cache descriptor, as defined earlier).
 
-`literals` (`String` or `Array` of `String`s to insert as is in the "CACHE:" section).
+* `literals` : `String` or `Array` of `String`s to insert as is in the "CACHE:" section.
 
-`pageslinks` a `Grunt globbing pattern` to defined all the pages to parse to extract `href` attribut
+* `pageslinks` a `Grunt globbing pattern` to defined all the pages to parse to extract `href` attribute
 of any kind of `link` tags and to extract `src` attribut of any `script` tag.
 This extraction will be added in the cache section. 
 
@@ -115,7 +113,7 @@ Files to be ignored and excluded from the "CACHE:" entries. This parameter has b
 #### setAttribut
 
 Type: `Grunt globbing pattern` 
-Default value: `undefined`.
+Default value: `undefined`
 [globbing pattern spec](http://gruntjs.com/configuring-tasks#globbing-patterns)
 
 Add attribut `manifest` into the html tag of files given with the globbing pattern with the value of
@@ -171,9 +169,9 @@ grunt.initConfig({
 
 ### Usage Examples with Bower
 
-Real web application are made this a lot of components. Components are now handle with bower.
-Here are examples to configure `grunt-appcache` to generate a cache manifest even if
-your application is split into bower components.
+Real web applications are made by lots of pieces, which you can conveniently handle with Bower.
+Here you can find some examples to make so that `grunt-appcache` generates an AppCache manifest
+even when your application is split into Bower components.
 
 ```js
 grunt.initConfig({

--- a/README.md
+++ b/README.md
@@ -110,21 +110,6 @@ Files to be ignored and excluded from the "CACHE:" entries. This parameter has b
 
 `String` or `Array` of `String`s to insert as is in the "FALLBACK:" section.
 
-#### setAttribut
-
-Type: `Grunt globbing pattern` 
-Default value: `undefined`
-[globbing pattern spec](http://gruntjs.com/configuring-tasks#globbing-patterns)
-
-Add attribut `manifest` into the html tag of files given with the globbing pattern with the value of
-`baseUrl` followed by the basename of `dest'.
-
-This option is useful for project that have a build process. In development mode, usualy `grunt serve` 
-give access to source code. The purpose of this field is to test in production mode. After a 
-`grunt build` command that include this appcache task, you have a distribution webapp in you `dist` 
-folder with appcache activated. Just launch 'grunt serve:dist' to test you application with
-the aapcache and your minified app. 
-
 ### Usage Examples
 
 In this example, the module is set to generate an AppCache manifest from the contents of the `static` directory, placing the resulting manifest in `static/manifest.appcache`. The `basePath` option allows the module to generate paths relative to the `static` directory, instead of the directory where the gruntfile resides.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,13 @@
     "grunt": "~0.4.1"
   },
   "keywords": [
-    "grunt", "gruntplugin", "html5", "manifest", "appcache"
-  ]
+    "grunt",
+    "gruntplugin",
+    "html5",
+    "manifest",
+    "appcache"
+  ],
+  "dependencies": {
+    "cheerio": "~0.18.0"
+  }
 }

--- a/tasks/appcache.js
+++ b/tasks/appcache.js
@@ -52,8 +52,8 @@ module.exports = function (grunt) {
         var initial = array;
         var results = [];
         var seen = [];
-        initial.forEach( function(value, index) {
-            if( seen.indexOf( value) === -1) {
+        initial.forEach(function(value, index) {
+            if(seen.indexOf(value) === -1) {
                 seen.push(value);
                 results.push(array[index]);
             }
@@ -96,7 +96,7 @@ module.exports = function (grunt) {
             .map(function (path) {
                 return joinUrl(options.basePath, path);
             })
-            .forEach( function(filename) {
+            .forEach(function(filename) {
                 var manifest = appcache.readManifest(filename);
                 Array.prototype.push.apply(cache, manifest.cache);
                 Array.prototype.push.apply(network, manifest.network);
@@ -106,14 +106,14 @@ module.exports = function (grunt) {
 
         if (typeof this.data.cache === 'object') {
             // seconds add link to the cache
-            expand(this.data.cache.pageslinks).forEach( function(filename) {
-                var content = grunt.file.read( filename);
+            expand(this.data.cache.pageslinks).forEach(function(filename) {
+                var content = grunt.file.read(filename);
                 // parse css
                 (content.match(/<link\s+(?:[^>]+\s+)*rel=(?:"\s*|'\s*)?[^>]*>/ig) || [])
                 .forEach(function(css) {
                     var src = css.match(/href=(?:"\s*|'\s*)?([^>"']+)\s*(?:'|"|\s)?/i)[1].trim();
                     if (!/^['"]?data:/i.test(src)) {
-                         cache.push(src);
+                        cache.push(src);
                     }
                 });
 
@@ -123,7 +123,7 @@ module.exports = function (grunt) {
                     var src = script.match(/src=["']?\s*([^>"']+)\s*["']?/i)[1].trim();
                     if (!/^['"]?data:/i.test(src)) {
                         cache.push(src);
-                    }                    
+                    }
                 });
             });
 
@@ -165,14 +165,14 @@ module.exports = function (grunt) {
 
         if (this.data.setAttribut) {
             // compute the url of the manifest. ex: dest='dist/manifest.appcache' -> /manifest.appcache
-            var startIndex = this.data.dest.indexOf( '/');
-            var baseName = this.data.dest.substring( startIndex === -1 ? 0 : startIndex+1);
+            var startIndex = this.data.dest.indexOf('/');
+            var baseName = this.data.dest.substring(startIndex === -1 ? 0 : startIndex+1);
             var webName = self.data.baseUrl ? joinUrl(self.data.baseUrl, baseName) : baseName;
             expand(this.data.setAttribut)
-            .forEach( function(filename) {
-                var content = grunt.file.read( filename);
-                var tmp = content.replace( /manifest=["']?\s*[^>"']+\s*["']?/ig, '');
-                grunt.file.write( filename, tmp.replace( '<html', '<html manifest="'+webName+'"'));
+            .forEach(function(filename) {
+                var content = grunt.file.read(filename);
+                var tmp = content.replace(/manifest=["']?\s*[^>"']+\s*["']?/ig, '');
+                grunt.file.write(filename, tmp.replace('<html', '<html manifest="'+webName+'"'));
             });
         }
 

--- a/tasks/appcache.js
+++ b/tasks/appcache.js
@@ -156,19 +156,6 @@ module.exports = function (grunt) {
             return false;
         }
 
-        if (this.data.setAttribut) {
-            // compute the url of the manifest. ex: dest='dist/manifest.appcache' -> /manifest.appcache
-            var startIndex = this.data.dest.indexOf('/');
-            var baseName = this.data.dest.substring(startIndex === -1 ? 0 : startIndex+1);
-            var webName = self.data.baseUrl ? joinUrl(self.data.baseUrl, baseName) : baseName;
-            expand(this.data.setAttribut)
-            .forEach(function(filename) {
-                var content = grunt.file.read(filename);
-                var tmp = content.replace(/manifest=["']?\s*[^>"']+\s*["']?/ig, '');
-                grunt.file.write(filename, tmp.replace('<html', '<html manifest="'+webName+'"'));
-            });
-        }
-
         grunt.log.writeln('AppCache manifest "' +
                 path.basename(output) +
                 '" created.');

--- a/tasks/appcache.js
+++ b/tasks/appcache.js
@@ -102,19 +102,19 @@ module.exports = function (grunt) {
             // seconds add link to the cache
             expand(this.data.cache.pageslinks).forEach(function(filename) {
                 var content = grunt.file.read(filename);
-                var $ = cheerio.load( content); 
+                var $ = cheerio.load(content); 
                 // parse links
                 $('link[href]').each(function() {
                     var href = $(this).attr('href');
-                    if( href.indexOf('data:') !== 0) {
-                        cache.push(href);                     
+                    if(href.indexOf('data:') !== 0) {
+                        cache.push(href);
                     }
                 });
 
                 // parse scripts
                 $('script[src]').each(function() {
                     var src = $(this).attr('src');
-                    if( src.indexOf('data:') !== 0) {
+                    if(src.indexOf('data:') !== 0) {
                         cache.push(src);                     
                     }
                 });

--- a/tasks/appcache.js
+++ b/tasks/appcache.js
@@ -11,6 +11,7 @@
 module.exports = function (grunt) {
 
     var path = require('path');
+    var cheerio = require('cheerio');
     var appcache = require('./lib/appcache').init(grunt);
 
     function array(input) {
@@ -101,21 +102,20 @@ module.exports = function (grunt) {
             // seconds add link to the cache
             expand(this.data.cache.pageslinks).forEach(function(filename) {
                 var content = grunt.file.read(filename);
-                // parse css
-                (content.match(/<link\s+(?:[^>]+\s+)*rel=(?:"\s*|'\s*)?[^>]*>/ig) || [])
-                .forEach(function(css) {
-                    var src = css.match(/href=(?:"\s*|'\s*)?([^>"']+)\s*(?:'|"|\s)?/i)[1].trim();
-                    if (!/^['"]?data:/i.test(src)) {
-                        cache.push(src);
+                var $ = cheerio.load( content); 
+                // parse links
+                $('link[href]').each(function() {
+                    var href = $(this).attr('href');
+                    if( href.indexOf('data:') !== 0) {
+                        cache.push(href);                     
                     }
                 });
 
                 // parse scripts
-                (content.match(/<script\s+(?:[^>]+\s+)?src=["']?\s*([^>]+)\s*["']?[\s>\/]/ig) || [])
-                .forEach(function(script) {
-                    var src = script.match(/src=["']?\s*([^>"']+)\s*["']?/i)[1].trim();
-                    if (!/^['"]?data:/i.test(src)) {
-                        cache.push(src);
+                $('script[src]').each(function() {
+                    var src = $(this).attr('src');
+                    if( src.indexOf('data:') !== 0) {
+                        cache.push(src);                     
                     }
                 });
             });

--- a/tasks/appcache.js
+++ b/tasks/appcache.js
@@ -88,7 +88,7 @@ module.exports = function (grunt) {
             // first parse appcache files to include it
             expand(this.data.includes, options.basePath)
             .map(function (path) {
-                return joinUrl(options.basePath, path);
+                return options.basePath ? joinUrl(options.basePath, path) : path;
             })
             .forEach(function(filename) {
                 var manifest = appcache.readManifest(filename);

--- a/tasks/appcache.js
+++ b/tasks/appcache.js
@@ -49,16 +49,9 @@ module.exports = function (grunt) {
     }
 
     function uniq(array) {
-        var initial = array;
-        var results = [];
-        var seen = [];
-        initial.forEach(function(value, index) {
-            if(seen.indexOf(value) === -1) {
-                seen.push(value);
-                results.push(array[index]);
-            }
+        return array.filter(function (value, index) {
+            return array.indexOf(value) === index;
         });
-        return results;
     }
 
     grunt.registerMultiTask('appcache', 'Automatically generates an HTML5 AppCache manifest from a list of files.', function () {


### PR DESCRIPTION
- move baseUrl from options to data to have a different behavior between webapp and web component
- generate full or partial appcache for web components
- feed appcache with partial manifest file with includes field
- feed appcache with parsing html files with pageslinks field
- auto inject manifest in html pages with setAttribut field

More information in the Readme.md